### PR TITLE
add usb cdc mode flag and delay after serial initialization

### DIFF
--- a/basic/platformio.ini
+++ b/basic/platformio.ini
@@ -25,6 +25,8 @@ monitor_filters = default esp32_exception_decoder
 [flags]
 build_flags =
     -std=gnu++2a
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
 build_unflags =
     -std=c++11 -std=c++14 -std=c++17 -std=gnu++11 -std=gnu++14 -std=gnu++17
 

--- a/basic/src/main.cpp
+++ b/basic/src/main.cpp
@@ -21,6 +21,7 @@ float sensor;
 void setup() {
     #ifdef Arduino_h
         Serial.begin(115200);
+        delay(1000);
     #endif
 
     /*


### PR DESCRIPTION
looking at : 

https://www.reddit.com/r/esp32/comments/1ixp1g9/esp32s3_serial_output_using_arduino/
https://thingpulse.com/usb-settings-for-logging-with-the-esp32-s3-in-platformio/?srsltid=AfmBOorkuMOkMcCDctobBpJzPvPb4KKHulrpQ1uh2ZFhxDF4edDpQBP6

I added the build flags to use esp32 over usb cdc for serial communication, which takes longer time to initialize than UART with other esp32 variants? 

As well as a 1000ms delay after `Serial.begin()`, which seems to fix the std::cout message printing, early in the boot process

